### PR TITLE
상세 페이지 제작

### DIFF
--- a/frontend/src/Component/Detail/DetailCard.tsx
+++ b/frontend/src/Component/Detail/DetailCard.tsx
@@ -1,0 +1,80 @@
+import {
+  Avatar,
+  Box,
+  Button,
+  Card,
+  CardMedia,
+  Chip,
+  Rating,
+  Typography,
+} from '@mui/material';
+import { IData } from '../../Util/Type';
+
+interface IDetailCard {
+  post: IData;
+}
+
+interface IUserInfo {
+  userImg: string;
+  userName: string;
+  short_desc: string;
+  score: number;
+}
+
+const UserInfo: React.FC<IUserInfo> = ({
+  userImg,
+  score,
+  userName,
+  short_desc,
+}) => {
+  return (
+    <Box className='detail-user-info'>
+      <Box className='user-avatar'>
+        <Avatar alt='user' src={userImg} className='user-img' />
+        <Typography>{userName}</Typography>
+      </Box>
+      <Box className='detail-user-description'>
+        <Box className='detail-user-score'>
+          <Typography className='user-score'>{score.toFixed(1)}</Typography>
+          <Rating className='user-star-score' value={score} readOnly />
+        </Box>
+        <Typography className='user-short_desc'>{short_desc}</Typography>
+      </Box>
+    </Box>
+  );
+};
+
+const DetailCard: React.FC<IDetailCard> = ({ post }) => {
+  return (
+    <Card className='detail-card-container'>
+      <Box className='detail-main-image'>
+        <CardMedia
+          className='card-img'
+          component='img'
+          image={post.img}
+          alt='user-image'
+        />
+        <Box className='card-label-container'>
+          {post.label.map((label, idx) => (
+            <Chip key={idx} className='card-label' label={label} />
+          ))}
+        </Box>
+      </Box>
+      <Box className='detail-content-container'>
+        <Typography className='post-title'>{post.title}</Typography>
+        <UserInfo
+          short_desc={post.User.short_desc}
+          userImg={post.User.img}
+          userName={post.User.name}
+          score={post.User.score}
+        />
+        <Typography className='post-desc'>{post.desc}</Typography>
+        <Button variant='contained' className='ask-btn'>
+          문의하러 가기
+        </Button>
+      </Box>
+    </Card>
+  );
+};
+
+export default DetailCard;

--- a/frontend/src/Component/Detail/InfomationCard.tsx
+++ b/frontend/src/Component/Detail/InfomationCard.tsx
@@ -1,0 +1,96 @@
+import {
+  Box,
+  Divider,
+  Grid,
+  List,
+  ListItem,
+  ListItemIcon,
+  ListItemText,
+  Typography,
+} from '@mui/material';
+import MilitaryTechIcon from '@mui/icons-material/MilitaryTech';
+import LocationOnIcon from '@mui/icons-material/LocationOn';
+import AccessTimeFilledIcon from '@mui/icons-material/AccessTimeFilled';
+import ApartmentIcon from '@mui/icons-material/Apartment';
+import EmojiEventsIcon from '@mui/icons-material/EmojiEvents';
+import InboxIcon from '@mui/icons-material/Inbox';
+import { useState } from 'react';
+import React from 'react';
+import { IInfomation } from '../../Util/Type';
+import { BASIC_INFO_TYPE, EXTRA_INFO_TYPE } from '../../Util/Constant';
+
+interface IInfomationCard {
+  basicInfoList: IInfomation[];
+  extraInfoList: IInfomation[];
+}
+
+interface IInfomationComponent {
+  infoList: IInfomation[];
+  dense: boolean;
+  title: string;
+}
+
+interface IListItem {
+  type: number;
+  info: string;
+}
+
+const CustomListItem: React.FC<IListItem> = ({ type, info }) => {
+  return (
+    <ListItem>
+      <ListItemIcon>
+        {type === BASIC_INFO_TYPE.CERTIFICATION && <MilitaryTechIcon />}
+        {type === BASIC_INFO_TYPE.GIVE && <EmojiEventsIcon />}
+        {type === BASIC_INFO_TYPE.LOCATION && <LocationOnIcon />}
+        {type === BASIC_INFO_TYPE.TIME && <AccessTimeFilledIcon />}
+        {type === EXTRA_INFO_TYPE.CAREER && <ApartmentIcon />}
+        {type === EXTRA_INFO_TYPE.NONE && <InboxIcon />}
+      </ListItemIcon>
+      <ListItemText primary={info} />
+    </ListItem>
+  );
+};
+
+const InfomationComponent: React.FC<IInfomationComponent> = ({
+  dense,
+  infoList,
+  title,
+}) => {
+  return (
+    <Box className='infomation-container'>
+      <Typography variant='h5'>{title}</Typography>
+      <Divider sx={{ marginTop: '5%' }} />
+      <Grid item xs={12} md={6} className='infomation-grid'>
+        <List dense={dense}>
+          {infoList.map((item) => (
+            <CustomListItem key={item.id} type={item.type} info={item.info} />
+          ))}
+        </List>
+      </Grid>
+    </Box>
+  );
+};
+
+const InfomationCard: React.FC<IInfomationCard> = ({
+  basicInfoList,
+  extraInfoList,
+}) => {
+  const [dense] = useState<boolean>(false);
+
+  return (
+    <List className='infomation-card-container'>
+      <InfomationComponent
+        title='기본 정보'
+        dense={dense}
+        infoList={basicInfoList}
+      />
+      <InfomationComponent
+        title='추가 정보'
+        dense={dense}
+        infoList={extraInfoList}
+      />
+    </List>
+  );
+};
+
+export default InfomationCard;

--- a/frontend/src/Component/Detail/index.tsx
+++ b/frontend/src/Component/Detail/index.tsx
@@ -1,0 +1,58 @@
+import { useLayoutEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { TempData } from '../../Util/TempData';
+import { IData, IInfomation } from '../../Util/Type';
+import DetailCard from './DetailCard';
+import InfomationCard from './InfomationCard';
+
+const initialPost: IData = {
+    id: 0,
+    desc: '',
+    title: '',
+    img: '',
+    label: [''],
+    User: {
+      id: 0,
+      img: '',
+      name: '',
+      score: 0,
+      short_desc: '',
+      basic_info: [{
+        id: 0,
+        type: 0,
+        info: '',
+      }],
+      extra_info: [{
+        id: 0,
+        type: 0,
+        info: '',
+      }]
+    }
+};
+
+const Detail: React.FC = () => {
+  const { postId } = useParams();
+  
+  const [post, setPost] = useState<IData>(initialPost);
+  const [basicInfoList, setBasicInfoList] = useState<IInfomation[]>([]);
+  const [extraInfoList, setExtraInfoList] = useState<IInfomation[]>([]);
+
+  useLayoutEffect(() => {
+    const nextPost = TempData[Number(postId) - 1];
+    setPost(nextPost);
+    setBasicInfoList(nextPost.User.basic_info as IInfomation[]);
+    setExtraInfoList(nextPost.User.extra_info as IInfomation[]);
+  }, [postId]);
+
+  return (
+    <div className='detail-container'>
+      <DetailCard post={post} />
+      <InfomationCard
+        basicInfoList={basicInfoList}
+        extraInfoList={extraInfoList}
+      />
+    </div>
+  );
+};
+
+export default Detail;

--- a/frontend/src/Page/DetailPage.tsx
+++ b/frontend/src/Page/DetailPage.tsx
@@ -1,0 +1,17 @@
+import Header from '../Component/Header';
+import Layout from '../Component/Layout';
+import Detail from '../Component/Detail';
+import Banner from '../Component/Banner';
+import '../scss/DetailPage.scss';
+
+const MainPage: React.FC = () => {
+  return (
+    <Layout>
+      <Header />
+      <Banner />
+      <Detail />
+    </Layout>
+  );
+};
+
+export default MainPage;

--- a/frontend/src/Page/index.ts
+++ b/frontend/src/Page/index.ts
@@ -1,1 +1,2 @@
 export { default as MainPage } from './MainPage';
+export { default as DetailPage } from './DetailPage';

--- a/frontend/src/Routes/index.tsx
+++ b/frontend/src/Routes/index.tsx
@@ -1,11 +1,12 @@
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
-import { MainPage } from '../Page';
+import { DetailPage, MainPage } from '../Page';
 
 const Router: React.FC = () => {
   return (
     <BrowserRouter>
       <Routes>
         <Route path='/' element={<MainPage />} />
+        <Route path='post/:postId' element={<DetailPage />} />
       </Routes>
     </BrowserRouter>
   );

--- a/frontend/src/Util/Constant.ts
+++ b/frontend/src/Util/Constant.ts
@@ -2,3 +2,15 @@ export const SHARE_INFO = {
   TALENT: 0,
   ITEM: 1,
 }
+
+export const BASIC_INFO_TYPE = {
+  CERTIFICATION: 0,
+  GIVE: 1,
+  LOCATION: 2,
+  TIME: 3,
+}
+
+export const EXTRA_INFO_TYPE = {
+  NONE: 1000,
+  CAREER: 1001,
+}

--- a/frontend/src/Util/TempData.ts
+++ b/frontend/src/Util/TempData.ts
@@ -1,15 +1,52 @@
+import { BASIC_INFO_TYPE, EXTRA_INFO_TYPE } from './Constant';
+
 export const TempData = [
   {
     id: 1,
     title: '나보다 바퀴벌레를 잘 잡는 사람이 있을까?',
     label: ['바퀴벌레', '자취방'],
     desc: '백년 묵은 바퀴벌레 다 잡아드립니다. 지금 침대 위에서 벌벌떨고 있다면 연락주세요. 화장실, 천장, 책상 모두 처리 가능합니다. 궁금하신 사항의 있으면 연락주세요.',
+    img: 'https://www.macmillandictionary.com/us/external/slideshow/full/Grey_full.png',
     User: {
       id: 1,
-      img: '/logo512.png',
+      img: 'https://avatars.githubusercontent.com/u/43488305?v=4',
       name: '상민',
-      score: 4.4,
+      score: 4.1,
       short_desc: '바퀴벌레 전문가, 나로 말할 것 같으면',
+      basic_info: [
+        {
+          id: 0,
+          type: BASIC_INFO_TYPE.CERTIFICATION,
+          info: '2022.02.08',
+        },
+        {
+          id: 1,
+          type: BASIC_INFO_TYPE.GIVE,
+          info: '3회 기부 완료',
+        },
+        {
+          id: 2,
+          type: BASIC_INFO_TYPE.LOCATION,
+          info: '시립대 후문',
+        },
+        {
+          id: 3,
+          type: BASIC_INFO_TYPE.TIME,
+          info: '09:00 ~ 22:00',
+        },
+      ],
+      extra_info: [
+        {
+          id: 1000,
+          type: EXTRA_INFO_TYPE.CAREER,
+          info: '경력 10년',
+        },
+        {
+          id: 1001,
+          type: EXTRA_INFO_TYPE.NONE,
+          info: '추가되는 라벨',
+        },
+      ],
     },
   },
   {
@@ -17,12 +54,47 @@ export const TempData = [
     title: '내가 바로 요리왕',
     label: ['요리', '자취방'],
     desc: '원하시는 요리 다 해드립니다. 파스타부터 볶음밥만 가능하고요 부모님의 손 맛이 그리워 지셨다면 언제든지 연락 주세요. 모든 요리 대신 해드립니다.',
+    img: 'https://www.macmillandictionary.com/us/external/slideshow/full/Grey_full.png',
     User: {
       id: 2,
-      img: '/logo512.png',
+      img: 'https://avatars.githubusercontent.com/u/86864534?s=88&u=43e1e9f8113d19da3c3b8e8b656e4b758beff36e&v=4',
       name: '인우',
-      score: 4.5,
+      score: 5.0,
       short_desc: '엄마 손 전문가, 나로 말할 것 같으면',
+      basic_info: [
+        {
+          id: 0,
+          type: BASIC_INFO_TYPE.CERTIFICATION,
+          info: '2022.02.08',
+        },
+        {
+          id: 1,
+          type: BASIC_INFO_TYPE.GIVE,
+          info: '10회 기부 완료',
+        },
+        {
+          id: 2,
+          type: BASIC_INFO_TYPE.LOCATION,
+          info: '시립대 정문',
+        },
+        {
+          id: 3,
+          type: BASIC_INFO_TYPE.TIME,
+          info: '03:00 ~ 10:00',
+        },
+      ],
+      extra_info: [
+        {
+          id: 1000,
+          type: EXTRA_INFO_TYPE.CAREER,
+          info: '경력 23년',
+        },
+        {
+          id: 1001,
+          type: EXTRA_INFO_TYPE.NONE,
+          info: '추가되는 라벨',
+        },
+      ],
     },
   },
   {
@@ -30,12 +102,47 @@ export const TempData = [
     title: '내가 바로 디자인의 대가, 디자인 대신 해드려요',
     label: ['디자인', '포토샵', '일러스트레이터'],
     desc: '아니 아직도 디자인이 어려우시다고요? 그럴 줄 알고 제가 왔습니다. 디자인이 필요한 부분이 있으면 언제든 연락 주세요. 일러스트레이터 포토샵 모두 가능합니다.',
+    img: 'https://www.macmillandictionary.com/us/external/slideshow/full/Grey_full.png',
     User: {
       id: 3,
-      img: '/logo512.png',
+      img: 'https://avatars.githubusercontent.com/u/90690578?s=88&u=19a324b3f507a41a6cac196adafb9c57e38587a7&v=4',
       name: '지함',
-      score: 4.5,
+      score: 5.0,
       short_desc: '포토샵 전문가, 나로 말할 것 같으면',
+      basic_info: [
+        {
+          id: 0,
+          type: BASIC_INFO_TYPE.CERTIFICATION,
+          info: '2022.02.08',
+        },
+        {
+          id: 1,
+          type: BASIC_INFO_TYPE.GIVE,
+          info: '32회 기부 완료',
+        },
+        {
+          id: 2,
+          type: BASIC_INFO_TYPE.LOCATION,
+          info: '시립대 전체',
+        },
+        {
+          id: 3,
+          type: BASIC_INFO_TYPE.TIME,
+          info: '09:00 ~ 22:00',
+        },
+      ],
+      extra_info: [
+        {
+          id: 1000,
+          type: EXTRA_INFO_TYPE.CAREER,
+          info: '경력 22년',
+        },
+        {
+          id: 1001,
+          type: EXTRA_INFO_TYPE.NONE,
+          info: '추가되는 라벨',
+        },
+      ],
     },
   },
 ];

--- a/frontend/src/Util/Type.ts
+++ b/frontend/src/Util/Type.ts
@@ -4,6 +4,8 @@ export interface IUser {
   name: string,
   score: number,
   short_desc: string,
+  basic_info: IInfomation[],
+  extra_info: IInfomation[],
 }
 
 export interface IData {
@@ -11,5 +13,12 @@ export interface IData {
   title: string,
   label: string[],
   desc: string,
+  img: string,
   User: IUser,
+}
+
+export interface IInfomation {
+  id: number,
+  type: number,
+  info: string,
 }

--- a/frontend/src/scss/DetailPage.scss
+++ b/frontend/src/scss/DetailPage.scss
@@ -1,0 +1,22 @@
+// default scss
+@import './base/base';
+@import './base/variable';
+@import './base/mixin';
+
+// components scss
+@import './component/layout';
+@import './component/header';
+@import './component/mainBanner';
+@import './component/detailCard';
+@import './component/infomation';
+
+.detail-container {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 5%;
+  margin-bottom: 5%;
+
+  @include mobile {
+    flex-direction: column;
+  }
+}

--- a/frontend/src/scss/component/_detailCard.scss
+++ b/frontend/src/scss/component/_detailCard.scss
@@ -1,0 +1,96 @@
+.detail-card-container {
+  display: flex;
+  padding: 3%;
+  width: 70%;
+  height: 100%;
+
+  @include mobile {
+    width: 100%;
+    flex-direction: column;
+  }
+  .detail-main-image {
+    width: 40%;
+    flex-grow: 1;
+    
+    @include mobile {
+      width: 100%;
+    }
+    img {
+      max-width: 100%;
+      border: 1px solid #e5e5e5;
+      border-radius: 15px;
+    }
+
+    .card-label-container {
+      margin-top: 5%;
+    }
+  }
+
+  .detail-content-container {
+    width: 60%;
+    margin-left: 5%;
+
+    @include mobile {
+      margin-left: 0%;
+      margin-top: 10%;
+      width: 100%;
+    }
+
+    .post-title {
+      @include font-default(700, 1.3rem);
+      padding-bottom: 3%;
+      border-bottom: 1px solid #a5a5a5;
+    }
+
+    .detail-user-info {
+      display: flex;
+      justify-content: space-evenly;
+      text-align: center;
+      margin: 3% auto;
+
+      .user-avatar {
+        .user-img {
+          width: 75px;
+          height: 75px;
+        }
+
+        p {
+          margin-top: 10%;
+        }
+      }
+
+      .detail-user-description {
+        display: flex;
+        flex-direction: column;
+        justify-content: space-evenly;
+
+        .detail-user-score {
+          display: flex;
+          align-items: center;
+
+          .user-score {
+            @include font-default(600, 1.3rem);
+          }
+
+          .user-star-score {
+            margin-left: 3%;
+          }
+        }
+        
+        .user-short_desc {
+          @include font-default(300, 0.8rem);
+          color: #8a8787;
+        }
+      } 
+    }
+
+    .post-desc {
+      margin: 10% auto;
+    }
+
+    .ask-btn {
+      width: 100%;
+      background-color: #6eb7e9;
+    }
+  }
+}

--- a/frontend/src/scss/component/_filter.scss
+++ b/frontend/src/scss/component/_filter.scss
@@ -8,6 +8,10 @@
   border: 1px solid #6eb7e9;
   white-space:nowrap;
 
+  @include mobile {
+    width: 100%;
+  }
+
   .filter-option-title {
     @include font-default(700, 1.2rem);
   }

--- a/frontend/src/scss/component/_header.scss
+++ b/frontend/src/scss/component/_header.scss
@@ -68,6 +68,9 @@
 
   .header-logo {
     width: 15%;
+    @include mobile {
+      width: 35%;
+    }
     cursor: pointer;
     img {
       max-width: 100%;

--- a/frontend/src/scss/component/_infomation.scss
+++ b/frontend/src/scss/component/_infomation.scss
@@ -1,0 +1,29 @@
+.infomation-card-container {
+  display: flex;
+  flex-direction: column;
+  width: 20%;
+  height: 100%;
+  text-align: center;
+  
+  @include mobile {
+    width: 100%;
+    flex-direction: row;
+    flex-wrap: wrap;
+  }
+
+  .infomation-container {
+    margin: 0 auto;
+    border: 1px solid #a5a5a5;
+    padding: 5%;
+    border-radius: 15px;
+
+    &:last-child {
+      margin-top: 10%;
+    }
+  }
+
+  .infomation-grid {
+    width: 100%;
+    white-space: nowrap;
+  }
+}

--- a/frontend/src/scss/component/_shareCardTab.scss
+++ b/frontend/src/scss/component/_shareCardTab.scss
@@ -2,6 +2,10 @@
 .share-tab-container {
   width: 50%;
 
+  @include mobile {
+    width: 100%;
+  }
+
   .Mui-selected {
     @include font-default(500, 1rem);
   }


### PR DESCRIPTION
# #6 상세 페이지 제작(디테일 페이지)

## 🔨 작업 내용 설명

- 상세 페이지를 제작 했습니다.
- `/post/:postId`로 라우팅했습니다.
- 상세페이지에서 기존에 피그마에서 디자인했던 회색부분을 기본정보와 추가정보를 도입했습니다.
- 정보를 도입하면서 TempData에서 사용하던 유저부분의 값들을 업데이트 했습니다.
- InfomationCard의 재사용성을 높이면서 기본정보와 추가정보를 모두 다룹니다.

### 📑 구현한 내용

- [x] 상세페이지 제작
- [x] 데이터 타입 맞추기

### 스크린 샷
<img width="1190" alt="image" src="https://user-images.githubusercontent.com/43488305/153316062-ccfdb887-c5c9-4442-a5c0-d5360c850189.png">
