### PR TITLE
[Refactor] socket refactor

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -25,10 +25,10 @@ export default class App {
     this.route();
   }
 
-  private config() {
+  private async config() {
     this.app.use(express.urlencoded({ extended: false })); // body parsing
     this.app.use(express.json()); // json parsing
-    this.app.use(passport.initialize());
+    await this.app.use(passport.initialize());
     this.app.use(
       session({
         secret: 'asadlfkj!@#!@#dfgasdg',
@@ -37,8 +37,9 @@ export default class App {
         store: new FileStore(),
       })
     );
+    this.app.use(passport.session());
     passportAPI.observerLocalLogin();
-    DBConfig.connectionDB();
+    await DBConfig.connectionDB();
   }
 
   private middleware() {

--- a/backend/src/controllers/socket/socket.chat.controller.ts
+++ b/backend/src/controllers/socket/socket.chat.controller.ts
@@ -1,0 +1,24 @@
+import { Socket } from 'socket.io';
+import { DatabaseEvent } from '@src/types/socket-type';
+
+import { io } from '../../utils/socket';
+
+class SokcetChatController {
+  socket: Socket;
+
+  constructor(socket: Socket) {
+    this.socket = socket;
+  }
+
+  sendMessage(data) {
+    // TODO
+    // 데이터베이스 연동
+    io.emit(DatabaseEvent.upload, data);
+  }
+
+  leaveChat() {
+    console.log(`[Socket] User ${this.socket.id} disconnected`);
+  }
+}
+
+export default SokcetChatController;

--- a/backend/src/types/socket-type.ts
+++ b/backend/src/types/socket-type.ts
@@ -1,0 +1,12 @@
+export enum ConnectionEvent {
+  connection = 'connection',
+  disconnection = 'disconnection',
+}
+
+export enum ChatEvent {
+  message = 'message',
+}
+
+export enum DatabaseEvent {
+  upload = 'upload',
+}

--- a/frontend/src/Component/Chat/ChatDetail.tsx
+++ b/frontend/src/Component/Chat/ChatDetail.tsx
@@ -1,25 +1,19 @@
-import { Box, Typography, Card, TextField, Avatar } from '@mui/material';
 import SendIcon from '@mui/icons-material/Send';
 import { useState, useEffect, useLayoutEffect, useRef } from 'react';
-import React from 'react';
-import { Socket } from 'socket.io-client';
+import { Box, Typography, Card, TextField, Avatar } from '@mui/material';
 
-import {
-  ChatType,
-  ServerToClientEvents,
-  ClientToServerEvents,
-} from '../../Util/Type';
-import { BOTTOM_HEIGHT } from '../../Util/Constant';
 import ChatCard from './ChatCard';
+import { ChatType } from '../../Util/Type';
+import socketAPI from '../../Util/SocketAPI';
+import useChatList from '../../Hook/useChatList';
+import { BOTTOM_HEIGHT } from '../../Util/Constant';
 import {
   ChatDetailTopSkeleton,
   ChatMsgSkeletonContainer,
 } from './ChatSkeleton';
-import useChatList from '../../Hook/useChatList';
 
 interface ChatRoomProps {
   chatData: ChatType;
-  socket: Socket<ServerToClientEvents, ClientToServerEvents>;
   isLoading: boolean;
 }
 
@@ -28,11 +22,7 @@ interface ChatContent {
   senderName: string;
 }
 //isLoading 상위 index에서 fetch,  loading 그걸로 실제 데이터 가공 여부
-const ChatDetail: React.FC<ChatRoomProps> = ({
-  chatData,
-  socket,
-  isLoading,
-}) => {
+const ChatDetail: React.FC<ChatRoomProps> = ({ chatData, isLoading }) => {
   const [myName, setMyName] = useState<string>('keroro');
   const [inputMessage, setInputMessage] = useState<string>('');
   const [loading, setLoading] = useState<boolean>(true);
@@ -50,7 +40,7 @@ const ChatDetail: React.FC<ChatRoomProps> = ({
 
   const handleEnter = (event: React.KeyboardEvent<HTMLDivElement>) => {
     if (event.key === 'Enter') {
-      socket.send({
+      socketAPI.sendMessage({
         message: inputMessage,
         senderName: myName,
       });
@@ -59,7 +49,7 @@ const ChatDetail: React.FC<ChatRoomProps> = ({
   };
 
   const handleBtnClick = () => {
-    socket.send({ message: inputMessage, senderName: myName });
+    socketAPI.sendMessage({ message: inputMessage, senderName: myName });
     setInputMessage('');
   };
 
@@ -79,11 +69,9 @@ const ChatDetail: React.FC<ChatRoomProps> = ({
         scrollToBottom();
       });
     };
-    socket.on('upload', handler);
-    return () => {
-      socket.off('upload', handler);
-    };
-  }, [addChat, myName, socket]);
+    socketAPI.onEvent('upload', handler);
+    return () => socketAPI.offEvent('upload', handler);
+  }, [addChat, myName]);
 
   return (
     <Box className='chat-detail-container'>

--- a/frontend/src/Component/Chat/ChatList.tsx
+++ b/frontend/src/Component/Chat/ChatList.tsx
@@ -1,19 +1,13 @@
 import { Box, Typography } from '@mui/material';
 import { Dispatch, SetStateAction } from 'react';
-import { Socket } from 'socket.io-client';
 
 import ChatPerson from './ChatPerson';
-import {
-  ChatType,
-  ServerToClientEvents,
-  ClientToServerEvents,
-} from '../../Util/Type';
+import { ChatType } from '../../Util/Type';
 import { ChatListHeaderSkeleton, ChatPersonSkeleton } from './ChatSkeleton';
 
 interface IChatSelect {
   setChatRoom: Dispatch<SetStateAction<number>>;
   chatList: ChatType[];
-  socket: Socket<ServerToClientEvents, ClientToServerEvents>;
   isLoading: boolean;
 }
 
@@ -22,7 +16,6 @@ const skeletonChat = [0, 0, 0, 0, 0];
 const ChatList: React.FC<IChatSelect> = ({
   setChatRoom,
   chatList,
-  socket,
   isLoading,
 }) => {
   return (

--- a/frontend/src/Component/Chat/index.tsx
+++ b/frontend/src/Component/Chat/index.tsx
@@ -1,43 +1,16 @@
 import { Box } from '@mui/material';
-import { io, Socket } from 'socket.io-client';
 import { useState, useLayoutEffect } from 'react';
 
 import ChatList from './ChatList';
 import ChatDetail from './ChatDetail';
-import {
-  ChatType,
-  ServerToClientEvents,
-  ClientToServerEvents,
-} from '../../Util/Type';
+import { ChatType } from '../../Util/Type';
 import requestAPI from '../../Util/Request';
 import { LOADING } from '../../Util/Constant';
 
-const initialChat: ChatType = {
-  id: '',
-  User: {
-    id: '',
-    img: '',
-    nickname: '',
-  },
-  unwatched: 0,
-  last: '',
-  overview: '',
-};
-const initialChatList: ChatType[] = [initialChat];
-
-const socket: Socket<ServerToClientEvents, ClientToServerEvents> = io(
-  'http://localhost:8080/',
-  {
-    transports: ['websocket'],
-    upgrade: false,
-    forceNew: true,
-  }
-);
-
 const Chat: React.FC = () => {
   const [chatRoom, setChatRoom] = useState<number>(0);
-  const [chatList, setChatList] = useState<ChatType[]>(initialChatList);
-  const [chatData, setChatData] = useState<ChatType>(initialChat);
+  const [chatList, setChatList] = useState<ChatType[]>([] as ChatType[]);
+  const [chatData, setChatData] = useState<ChatType>({} as ChatType);
   const [loading, setLoading] = useState<boolean[]>([true, true]);
 
   useLayoutEffect(() => {
@@ -59,14 +32,9 @@ const Chat: React.FC = () => {
       <ChatList
         setChatRoom={setChatRoom}
         chatList={chatList}
-        socket={socket}
         isLoading={loading[LOADING.LIST]}
       />
-      <ChatDetail
-        chatData={chatData}
-        socket={socket}
-        isLoading={loading[LOADING.DETAIL]}
-      />
+      <ChatDetail chatData={chatData} isLoading={loading[LOADING.DETAIL]} />
     </Box>
   );
 };

--- a/frontend/src/Hook/useChatList.ts
+++ b/frontend/src/Hook/useChatList.ts
@@ -29,11 +29,10 @@ const useChatList = () => {
 
   const setPastChat = useCallback(
     async (chatData: ChatType, myName: string) => {
-      const pastChat: ChatContent[] = chatData!.content!.map((item) => {
+      const pastChat: ChatContent[] = chatData.content?.map((item) => {
         const singlePastChat = {
           message: item[0],
           isLeft: item[1] !== myName,
-          isFirstChat: item[1] !== myName,
         };
         return singlePastChat;
       });

--- a/frontend/src/Util/Constant.ts
+++ b/frontend/src/Util/Constant.ts
@@ -21,3 +21,7 @@ export enum LOADING {
   LIST,
   DETAIL,
 }
+
+export enum ChatEvent {
+  MESSAGE = 'message',
+}

--- a/frontend/src/Util/SocketAPI.ts
+++ b/frontend/src/Util/SocketAPI.ts
@@ -1,0 +1,30 @@
+import { io, Socket } from 'socket.io-client';
+
+import { ChatEvent } from './Constant';
+import { HandlerType, Message } from './Type';
+
+class SocketAPI {
+  socket: Socket;
+
+  constructor(server: string) {
+    this.socket = io(server, {
+      transports: ['websocket'],
+      upgrade: false,
+      forceNew: true,
+    });
+  }
+
+  sendMessage(newMessage: Message) {
+    this.socket.emit(ChatEvent.MESSAGE, newMessage);
+  }
+
+  onEvent(msg: string, handler: HandlerType) {
+    this.socket.on(msg, handler);
+  }
+
+  offEvent(msg: string, handler: HandlerType) {
+    this.socket.off(msg, handler);
+  }
+}
+
+export default new SocketAPI('http://localhost:8080');

--- a/frontend/src/Util/Type.ts
+++ b/frontend/src/Util/Type.ts
@@ -38,7 +38,7 @@ export interface ChatType {
   unwatched: number;
   last: string;
   overview: string;
-  content?: string[][];
+  content: string[][];
 }
 
 interface UserType {

--- a/frontend/src/Util/Type.ts
+++ b/frontend/src/Util/Type.ts
@@ -47,19 +47,9 @@ interface UserType {
   nickname: string;
 }
 
-interface ChatContent {
+export interface Message {
   message: string;
   senderName: string;
 }
 
-export interface ServerToClientEvents {
-  upload: (data: ChatContent) => void;
-}
-
-export interface ClientToServerEvents {
-  send: () => void;
-}
-
-export interface InterServerEvents {
-  ping: () => void;
-}
+export type HandlerType = (msg: Message) => void;


### PR DESCRIPTION
# 소켓 리팩토링입니다.

## 🔨 작업 내용 설명

- [x] (백엔드) socket controller를 만들면서 소켓 관련 이벤트 핸들링
- [x] (백엔드) socket event enum type 제작
- [x] (백엔드) socket 관련 오류가 떳던 부분 해결 (Connection socket error) 
- [x] (프론트) socketAPI 유틸 제작
- [x] (프론트) useChatList 훅에서 undefined오류 있던 부분 해결
 

### 📑 구현한 내용

백엔드에서 소켓을 다룰 일이 있다면 `controller/socket/*.ts` 의 형태로 만들어서 사용하면 소켓 관련 코드를 보기 더 쉬울 것 같아서 만들었습니다. 프론트와 백엔드에서 소켓 이벤트를 한 곳에서 다루면서 외부에서는 가독성을 더 좋게 만들기 위해서 리팩토링을 진행했습니다.

useChatList에서 undefined는 optional chaning이 적용이 되지 않아서 생겼던 문제이며, 관련해서 타입을 정정했습니다.

socket에서 Connection에러가 떳던 원흉은 `passport.initialize`에 있었던 것 같습니다. 해당 메서드는 동기적으로 작동하는 코드인 줄 알았으나, 실제로 확인해 본 결과 비동기적으로 작동을 했고 async await 키워드를 넣으니까 `constructor`에서 내부 메서드 호출을 어느 순서로해도 상관이 없었습니다. passport가 만들어지지 않아서 socket이 연결이 아직 되지 않았고, 그 사이에 프론트에서 접속을 시도해서 문제가 생겼던 것으로 현재는 추측하고 있습니다. 그러나 `passport.initialize` 의 코드를 비동기적으로 사용하는 레퍼런스는 찾기 어렵고, 실제 내부 구현도 어떤 느낌인지 잘 모르겠어서 정답은 아닐 수도 있으나 비동기로 작동하는 부분은 맞는 것 같습니다!
