### PR TITLE
[Fix] body-parser 안먹는 에러 해결

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -19,6 +19,8 @@ export default class App {
 
   constructor() {
     this.app = express();
+    this.app.use(express.urlencoded({ extended: false })); // body parsing
+    this.app.use(express.json()); // json parsing
     this.port = process.env.PORT || '8080';
     this.middleware();
     this.route();
@@ -26,9 +28,7 @@ export default class App {
   }
 
   private async config() {
-    this.app.use(express.urlencoded({ extended: false })); // body parsing
-    this.app.use(express.json()); // json parsing
-    await this.app.use(passport.initialize());
+    this.app.use(passport.initialize());
     this.app.use(
       session({
         secret: 'asadlfkj!@#!@#dfgasdg',


### PR DESCRIPTION
# Body parser 에러 해결

## 🔨 작업 내용 설명

- #32 해당 이슈를 해결하기 위해 async await를 사용하다보니까 body-parser가 passport init되기전에 실행이 안되는 듯한 작동을 보임
- 따라서, 임시방편으로 constructor 후에 바로 적용하면서 body-parser가 작동하게 동작
