### PR TITLE
Post Pagination API 작업

### DIFF
--- a/backend/src/controllers/post.controller.ts
+++ b/backend/src/controllers/post.controller.ts
@@ -19,7 +19,7 @@ class postController {
     }
   }
 
-  async getLimitedPost(req: Request, res: Response) {
+  async getPaginationPost(req: Request, res: Response) {
     try {
       const offset = req.query.offset;
       const limit = req.query.limit;

--- a/backend/src/controllers/post.controller.ts
+++ b/backend/src/controllers/post.controller.ts
@@ -1,4 +1,3 @@
-import { TempData } from '@src/utils/temp.data';
 import { Request, Response } from 'express';
 
 import PostRepository from '@src/db/repositories/post.repository';
@@ -11,17 +10,37 @@ class postController {
       const { postId } = req.params;
       const postRepo = getCustomRepository(PostRepository);
       const searchRes = await postRepo.findById(parseInt(postId));
+      if (searchRes.content === '')
+        return res.json({ status: 'error', error: 'empty post' });
 
-      return res.json(searchRes);
+      return res.json({ status: 'success', data: searchRes });
     } catch (err) {
       res.sendStatus(400);
     }
   }
 
-  async getAllPost(req: Request, res: Response) {
+  async getLimitedPost(req: Request, res: Response) {
     try {
-      console.log('send All Data');
-      return res.json(TempData);
+      const offset = req.query.offset;
+      const limit = req.query.limit;
+      const postRepo = getCustomRepository(PostRepository);
+
+      if (!limit || !offset)
+        return res.json({ status: 'error', error: 'empty params' });
+      if (typeof offset !== 'string' || typeof limit !== 'string')
+        return res.json({ status: 'error', error: 'wrong param types' });
+
+      const maxSize = await postRepo.getMaxSize();
+      if (parseInt(offset as string) >= maxSize)
+        return res.json({ status: 'err', err: 'out of range' });
+
+      const searchRes = await postRepo.getSomePost(
+        maxSize,
+        parseInt(offset as string),
+        parseInt(limit as string),
+      );
+
+      return res.json({ status: 'success', data: searchRes });
     } catch (err) {
       res.sendStatus(400);
     }

--- a/backend/src/db/repositories/post.repository.ts
+++ b/backend/src/db/repositories/post.repository.ts
@@ -7,6 +7,18 @@ class PostRepository extends Repository<PostEntity> {
   async findById(_id: number) {
     return this.findOne({ _id });
   }
+
+  async getMaxSize() {
+    return this.createQueryBuilder('post').select('(*)').getCount();
+  }
+
+  async getSomePost(maxSize: number, offset: number, limit: number) {
+    return this.createQueryBuilder('post')
+      .orderBy('created_at', 'DESC')
+      .offset(offset)
+      .limit(limit)
+      .getMany();
+  }
 }
 
 export default PostRepository;

--- a/backend/src/routes/post.router.ts
+++ b/backend/src/routes/post.router.ts
@@ -1,9 +1,9 @@
 import postController from '@src/controllers/post.controller';
-import { Request, Response, Router } from 'express';
+import { Router } from 'express';
 
 const postRouter = Router();
 
 postRouter.get('/:postId', postController.getOnePost);
-postRouter.get('', postController.getLimitedPost);
+postRouter.get('', postController.getPaginationPost);
 
 export default postRouter;

--- a/backend/src/routes/post.router.ts
+++ b/backend/src/routes/post.router.ts
@@ -4,6 +4,6 @@ import { Request, Response, Router } from 'express';
 const postRouter = Router();
 
 postRouter.get('/:postId', postController.getOnePost);
-postRouter.get('/', postController.getAllPost);
+postRouter.get('', postController.getLimitedPost);
 
 export default postRouter;


### PR DESCRIPTION
#40 Post Pagination API

## 🔨 작업 내용 설명

- Post Pagination을 위한 getSomePost API를 작성하였습니다. 
- getSomePost API는 /api/post?offset={$offset}&limit={$limit} 로 API 요청이 가능합니다.
- getSomePost는 created_at를 기준으로 가장 최신이 가장 위로 올라오도록 정렬한 후에 offset만큼 떨어진 곳으로부터 limit만큼 post data를 받아옵니다.
- 개별 Post API를 받아오는 API에 예외 처리를 추가했습니다.

### 📑 구현한 내용

- Post Pagination을 위한 getSomePost API를 작성하였습니다.

### 💁‍♂️ 전달 사항 

- API 전송 간에 에러 형식을 알리기 위해서 전송 데이터 형식을 { status: "err" | "success" , err | data = result }로 보냈습니다.
- getSomePost가 네이밍이 구리다고 생각했지만 더 좋은 것이 생각나지 않아서 그대로 작성하였습니다. 더 좋은 안이 있다면 추천 바랍니다.

### 스크린 샷 

![image](https://user-images.githubusercontent.com/86864534/167978783-a38c365d-5368-4c76-9d40-ea21b3d3c5e0.png)
