### PR TITLE
Post Api User 정보 포함 개선

### DIFF
--- a/backend/.eslintrc.json
+++ b/backend/.eslintrc.json
@@ -7,6 +7,7 @@
     "extends": [
       "eslint:recommended",
       "plugin:@typescript-eslint/recommended",
+      "@typescript-eslint/parser",
       "airbnb",
       "airbnb/hooks",
       "airbnb-typescript",
@@ -16,7 +17,8 @@
 "parserOptions": {
     "ecmaVersion": "latest",
     "sourceType": "module",
-    "project": "./backend/tsconfig.json"
+    "tsconfigRootDir": "__dirname",
+    "project": "./tsconfig.json"
 },
   "plugins": [
       "@typescript-eslint"

--- a/backend/src/controllers/post.controller.ts
+++ b/backend/src/controllers/post.controller.ts
@@ -36,11 +36,12 @@ class PostController {
         return res.json({ status: 'err', err: 'out of range' });
 
       const searchRes = await postRepo.getSomePost(
+        maxSize,
         parseInt(offset as string, 10),
         parseInt(limit as string, 10),
       );
 
-      return res.json({ status: 'success', data: searchRes });
+      return res.json({ status: 'success', data: searchRes.reverse() });
     } catch (err) {
       res.sendStatus(400);
     }

--- a/backend/src/controllers/post.controller.ts
+++ b/backend/src/controllers/post.controller.ts
@@ -36,7 +36,6 @@ class PostController {
         return res.json({ status: 'err', err: 'out of range' });
 
       const searchRes = await postRepo.getSomePost(
-        maxSize,
         parseInt(offset as string, 10),
         parseInt(limit as string, 10),
       );

--- a/backend/src/db/repositories/post.repository.ts
+++ b/backend/src/db/repositories/post.repository.ts
@@ -12,12 +12,15 @@ class PostRepository extends Repository<PostEntity> {
     return this.createQueryBuilder('post').select('(*)').getCount();
   }
 
-  async getSomePost(maxSize: number, offset: number, limit: number) {
-    return this.createQueryBuilder('post')
-      .orderBy('created_at', 'DESC')
-      .offset(offset)
-      .limit(limit)
-      .getMany();
+  async getSomePost(offset?: number, limit?: number) {
+    return await this.find({
+      relations: ['user_id'],
+      order: {
+        created_at: 'DESC',
+      },
+      skip: offset,
+      take: limit,
+    });
   }
 }
 

--- a/backend/src/db/repositories/post.repository.ts
+++ b/backend/src/db/repositories/post.repository.ts
@@ -5,7 +5,7 @@ import PostEntity from '@src/db/entities/post.entity';
 @EntityRepository(PostEntity)
 class PostRepository extends Repository<PostEntity> {
   async findById(_id: number) {
-    return this.findOne({ _id });
+    return this.findOne({ _id }, { relations: ['user_id'] });
   }
 
   async getMaxSize() {

--- a/backend/src/db/repositories/post.repository.ts
+++ b/backend/src/db/repositories/post.repository.ts
@@ -5,22 +5,31 @@ import PostEntity from '@src/db/entities/post.entity';
 @EntityRepository(PostEntity)
 class PostRepository extends Repository<PostEntity> {
   async findById(_id: number) {
-    return this.findOne({ _id }, { relations: ['user_id'] });
+    return this.createQueryBuilder('post')
+      .select(['post', 'post.user_id', 'user._id', 'user.nickname', 'user.img'])
+      .leftJoin('post.user_id', 'user')
+      .where('post._id = :id', { id: _id })
+      .getOne();
   }
 
   async getMaxSize() {
     return this.createQueryBuilder('post').select('(*)').getCount();
   }
 
-  async getSomePost(offset?: number, limit?: number) {
-    return await this.find({
-      relations: ['user_id'],
-      order: {
-        created_at: 'DESC',
-      },
-      skip: offset,
-      take: limit,
-    });
+  async getSomePost(maxSize: number, offset: number, limit: number) {
+    let startPoint = maxSize - (offset + limit);
+    let limitConvert = limit;
+    if (startPoint < 0) {
+      limitConvert += startPoint;
+      startPoint = 0;
+    }
+
+    return this.createQueryBuilder('post')
+      .select(['post', 'post.user_id', 'user._id', 'user.nickname', 'user.img'])
+      .leftJoin('post.user_id', 'user')
+      .skip(startPoint)
+      .take(limitConvert)
+      .getMany();
   }
 }
 


### PR DESCRIPTION
#40 Post APi User 정보 포함하도록 개선

## 🔨 작업 내용 설명

- Post API를 통해 정보를 받아올 때 User의 정보를 받아올 수 있도록 했습니다. 

### 📑 구현한 내용

- Post API의 두 메소드에 유저 정보를 포함시켰습니다.
- Join을 한 후에 Orderby를 하는 것에 오류가 있어서 이를 다른 방식으로 돌려서 구현했습니다. 

### 스크린 샷 
![image](https://user-images.githubusercontent.com/86864534/168973380-db6b5f8f-a047-4d37-887d-d31c704ee7c0.png)
