### PR TITLE
프론트 환경변수 설정

### DIFF
--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -14,7 +14,12 @@
   },
   "plugins": ["react", "react-hooks", "@typescript-eslint", "prettier"],
   "rules": {
-    "prettier/prettier": ["error"],
+    "prettier/prettier": [
+      "error",
+      {
+        "endOfLine": "auto"
+      }
+    ],
     "react/jsx-filename-extension": [
       2,
       {

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -21,3 +21,7 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# dotenv environment variables file
+.env
+.env.test

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,7 @@
     "@types/react-dom": "^17.0.9",
     "@types/react-swipeable-views": "^0.13.1",
     "axios": "^0.26.0",
+    "dotenv": "^16.0.1",
     "faker": "5.5.3",
     "node-sass": "^7.0.1",
     "react": "^17.0.2",

--- a/frontend/src/Component/Login/EasyLogin.tsx
+++ b/frontend/src/Component/Login/EasyLogin.tsx
@@ -5,10 +5,7 @@ const EasyLogin: React.FC = () => {
   const handleNaverClick = () => {};
 
   const handleKakaoClick = () => {
-    const REST_API_KEY = '6b190b1746f6460e0328fb561516d76f';
-    const REDIRECT_URI = 'http://localhost:3000/oauth/kakao/callback';
-
-    window.location.href = `https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=${REST_API_KEY}&redirect_uri=${REDIRECT_URI}`;
+    window.location.href = `https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=${process.env.REACT_APP_REST_API_KEY}&redirect_uri=${process.env.REACT_APP_REDIRECT_URI}`;
   };
 
   const handleGoogleClick = async () => {

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -4162,6 +4162,11 @@ dotenv@^10.0.0:
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-10.0.0.tgz#3d4227b8fb95f81096cdd2b66653fb2c7085ba81"
   integrity sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==
 
+dotenv@^16.0.1:
+  version "16.0.1"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.0.1.tgz#8f8f9d94876c35dac989876a5d3a82a267fdce1d"
+  integrity sha512-1K6hR6wtk2FviQ4kEiSjFiH5rpzEVi8WW0x96aztHVMhEspNpc4DVOUTEHtEva5VThQ8IaBX1Pe4gSzpVVUsKQ==
+
 duplexer@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.2.tgz#3abe43aef3835f8ae077d136ddce0f276b0400e6"


### PR DESCRIPTION
# 프론트 환경변수 설정

## 🔨 작업 내용 설명

- 프론트 쪽에서도 환경변수 `.env` 파일 사용할 수 있도록 설정했습니다.
- 'Delete CR' 에러를 해결했습니다.

### 💁‍♂️ 전달 사항

- 백엔드와 달리 프론트에서는 다음과 같은 코드가 필요하지 않습니다.
    ```
    import dotenv from 'dotenv';
    dotenv.config();
    ```

- 대신 `.env`에서 변수를 사용할 때 `REACT_APP_`을 앞에 붙여야 합니다.
